### PR TITLE
Be a replacement for waybar

### DIFF
--- a/waybar-hyprland/waybar-hyprland.spec
+++ b/waybar-hyprland/waybar-hyprland.spec
@@ -50,7 +50,7 @@ BuildRequires:  pkgconfig(wayland-protocols)
 BuildRequires:  pkgconfig(wireplumber-0.4)
 BuildRequires:  pkgconfig(xkbregistry)
 
-Conflicts:      waybar
+Provides:       waybar
 
 Enhances:       hyprland
 Recommends:     (font(fontawesome5free) or font(fontawesome))


### PR DESCRIPTION
By switching `Conflicts: waybar` to `Provides: waybar` we can prevent problems for those who need packages which depend on waybar.

In particular, this will make life easier for those using the Fedora sway spin, who can just run
 `dnf swap waybar waybar-hyprland`