### PR TITLE
hyprland-plugins/hyprland-plugins.spec: allow to override `build_for`

### DIFF
--- a/hyprland-plugins/hyprland-plugins.spec
+++ b/hyprland-plugins/hyprland-plugins.spec
@@ -16,7 +16,9 @@
                 xtra-dispatchers
 }
 
+%if !%{defined build_for}
 %global build_for release
+%endif
 
 %define pluginsmeta %{lua:
 if rpm.expand("%build_for") == "git" then


### PR DESCRIPTION
A small fix so we can pass `--define "buiid_for git"` to `rpmbuild`.